### PR TITLE
Update and clarify `dig` function documention.

### DIFF
--- a/lib/puppet/parser/functions/dig.rb
+++ b/lib/puppet/parser/functions/dig.rb
@@ -3,7 +3,8 @@ Puppet::Parser::Functions::newfunction(
   :type => :rvalue,
   :arity => -1,
   :doc => <<-DOC
-Returns a value for a sequence of given keys/indexes into a structure.
+Returns a value for a sequence of given keys/indexes into a structure, such as
+an array or hash.
 This function is used to "dig into" a complex data structure by
 using a sequence of keys / indexes to access a value from which
 the next key/index is accessed recursively.
@@ -13,14 +14,22 @@ The first encountered `undef` value or key stops the "dig" and `undef` is return
 An error is raised if an attempt is made to "dig" into
 something other than an `undef` (which immediately returns `undef`), an `Array` or a `Hash`.
 
+
+
 **Example:** Using `dig`
 
 ```puppet
 $data = {a => { b => [{x => 10, y => 20}, {x => 100, y => 200}]}}
-notice $data.dig(a, b, 1, x)
+notice $data.dig('a', 'b', 1, 'x')
 ```
 
 Would notice the value 100.
+
+This is roughly equivalent to `$data['a']['b'][1]['x']`. However, a standard
+index will return an error and cause catalog compilation failure if any parent
+of the final key (`'x'`) is `undef`. The `dig` function will return undef,
+rather than failing catalog compilation. This allows you to check if data
+exists in a structure without mandating that it always exists.
 
 * Since 4.5.0
 DOC


### PR DESCRIPTION
Currently, the dig function's documentation doesn't realllllly explain
what specifically what the function does, or what arguments are
expected, unless you're already familiar with the general concept of a
dig function.

  * Clarified that dig expects to be called on a hash or array, as
opposed to the generic term "structure" which, while accurate, is less
informative to the inexperienced.
  * Quoted all bare strings being passed to the dig function.
    - https://docs.puppet.com/puppet/5.0/style_guide.html#quoting
  * Explain the difference between using dig and standard indexing, as
part of the example text. While this is sort of explained earlier, it's
far from clear without explaining it alongside an example case.